### PR TITLE
Add district-related funtionality

### DIFF
--- a/GdanskExplorer/Controllers/DistrictController.cs
+++ b/GdanskExplorer/Controllers/DistrictController.cs
@@ -35,7 +35,8 @@ public class DistrictController : ControllerBase
             var dbDistricts = fc.Select(f =>
                 new District
                 {
-                    Area = (Polygon)f.Geometry,
+                    Geometry = (Polygon)f.Geometry,
+                    Area = f.Geometry.Area,
                     Id = new Guid(),
                     Name = (string)f.Attributes["DZIELNICY"]
                 }

--- a/GdanskExplorer/Controllers/DistrictController.cs
+++ b/GdanskExplorer/Controllers/DistrictController.cs
@@ -7,7 +7,7 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using Newtonsoft.Json;
 
-namespace GdanskExplorer;
+namespace GdanskExplorer.Controllers;
 
 [Authorize(Roles = "Admin")]
 [Route("[controller]")]

--- a/GdanskExplorer/Controllers/DistrictController.cs
+++ b/GdanskExplorer/Controllers/DistrictController.cs
@@ -1,5 +1,8 @@
 using System.Text.Json;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using GdanskExplorer.Data;
+using GdanskExplorer.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +11,7 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Annotations;
+using IConfigurationProvider = AutoMapper.IConfigurationProvider;
 
 namespace GdanskExplorer.Controllers;
 
@@ -15,10 +19,12 @@ namespace GdanskExplorer.Controllers;
 public class DistrictController : ControllerBase
 {
     private GExplorerContext _db;
+    private IMapper _mapper;
 
-    public DistrictController(GExplorerContext db)
+    public DistrictController(GExplorerContext db, IMapper mapper)
     {
         _db = db;
+        _mapper = mapper;
     }
 
     [HttpPost("import")]
@@ -51,5 +57,11 @@ public class DistrictController : ControllerBase
         }
 
         return Ok();
+    }
+
+    [HttpGet("")]
+    public IEnumerable<DistrictDto> GetAll()
+    {
+        return _mapper.ProjectTo<DistrictDto>(_db.Districts);
     }
 }

--- a/GdanskExplorer/Controllers/TripController.cs
+++ b/GdanskExplorer/Controllers/TripController.cs
@@ -16,11 +16,6 @@ namespace GdanskExplorer.Controllers;
 [Route("[controller]")]
 public class TripController : ControllerBase
 {
-    private static readonly string[] Summaries = new[]
-    {
-        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-    };
-
     private readonly ILogger<TripController> _logger;
     private readonly GExplorerContext _db;
     private readonly UserManager<User> _userManager;

--- a/GdanskExplorer/Data/District.cs
+++ b/GdanskExplorer/Data/District.cs
@@ -8,5 +8,4 @@ public class District
     public Polygon Geometry { get; set; } = null!;
     public double Area { get; set; }
     public string Name { get; set; } = null!;
-    
 }

--- a/GdanskExplorer/Data/District.cs
+++ b/GdanskExplorer/Data/District.cs
@@ -5,6 +5,7 @@ namespace GdanskExplorer.Data;
 public class District
 {
     public Guid Id { get; set; }
-    public Polygon Area { get; set; } = null!;
+    public Polygon Geometry { get; set; } = null!;
+    public double Area { get; set; }
     public string Name { get; set; } = null!;
 }

--- a/GdanskExplorer/Data/District.cs
+++ b/GdanskExplorer/Data/District.cs
@@ -8,4 +8,5 @@ public class District
     public Polygon Geometry { get; set; } = null!;
     public double Area { get; set; }
     public string Name { get; set; } = null!;
+    
 }

--- a/GdanskExplorer/DistrictController.cs
+++ b/GdanskExplorer/DistrictController.cs
@@ -1,0 +1,49 @@
+using GdanskExplorer.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using Newtonsoft.Json;
+
+namespace GdanskExplorer;
+
+[Authorize(Roles = "Admin")]
+[Route("[controller]")]
+public class DistrictController : ControllerBase
+{
+    private GExplorerContext _db;
+
+    public DistrictController(GExplorerContext db)
+    {
+        _db = db;
+    }
+
+    [HttpPost("import")]
+    public async Task<IActionResult> ImportDistricts()
+    {
+        var bodyString = await new StreamReader(HttpContext.Request.BodyReader.AsStream()).ReadToEndAsync();
+        var reader = new GeoJsonReader();
+        try
+        {
+            var fc = reader.Read<FeatureCollection>(bodyString);
+            var dbDistricts = fc.Select(f =>
+                new District
+                {
+                    Area = (Polygon)f.Geometry,
+                    Id = new Guid(),
+                    Name = (string)f.Attributes["DZIELNICY"]
+                }
+            );
+            await _db.Districts.ExecuteDeleteAsync();
+            await _db.Districts.AddRangeAsync(dbDistricts);
+        }
+        catch (JsonReaderException)
+        {
+            return BadRequest("bad GeoJSON body!");
+        }
+
+        return Ok();
+    }
+}

--- a/GdanskExplorer/Dtos/DistrictDto.cs
+++ b/GdanskExplorer/Dtos/DistrictDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+using NetTopologySuite.Geometries;
+
+namespace GdanskExplorer.Dtos;
+
+public class DistrictDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+
+    [JsonConverter(typeof(GeometryJsonConverter))]
+    public Geometry Geometry { get; set; } = null!;
+
+    public double Area { get; set; }
+}

--- a/GdanskExplorer/Extensions.cs
+++ b/GdanskExplorer/Extensions.cs
@@ -17,4 +17,7 @@ public static class Extensions
             Polygon polygon => new MultiPolygon(new[] { polygon }),
             _ => throw new ArgumentOutOfRangeException(nameof(g))
         };
+
+    public static async Task<IEnumerable<T1>> SelectManyAsync<T, T1>(this IEnumerable<T> enumeration,
+        Func<T, Task<IEnumerable<T1>>> func) => (await Task.WhenAll(enumeration.Select(func))).SelectMany(s => s);
 }

--- a/GdanskExplorer/GExplorerAutoMapperProfile.cs
+++ b/GdanskExplorer/GExplorerAutoMapperProfile.cs
@@ -12,5 +12,6 @@ public class GExplorerAutoMapperProfile : Profile
         CreateMap<User, UserReturnDto>();
         CreateMap<Trip, TripReturnDto>();
         CreateMap<Trip, DetailedTripReturnDto>();
+        CreateMap<District, DistrictDto>();
     }
 }

--- a/GdanskExplorer/GdanskExplorer.csproj
+++ b/GdanskExplorer/GdanskExplorer.csproj
@@ -26,6 +26,7 @@
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="7.0.11" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     </ItemGroup>
 
 

--- a/GdanskExplorer/Migrations/20231123210022_add cached area to district table.Designer.cs
+++ b/GdanskExplorer/Migrations/20231123210022_add cached area to district table.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GdanskExplorer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GdanskExplorer.Migrations
 {
     [DbContext(typeof(GExplorerContext))]
-    partial class GExplorerContextModelSnapshot : ModelSnapshot
+    [Migration("20231123210022_add cached area to district table")]
+    partial class addcachedareatodistricttable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GdanskExplorer/Migrations/20231123210022_add cached area to district table.cs
+++ b/GdanskExplorer/Migrations/20231123210022_add cached area to district table.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NetTopologySuite.Geometries;
+
+#nullable disable
+
+namespace GdanskExplorer.Migrations
+{
+    /// <inheritdoc />
+    public partial class addcachedareatodistricttable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Area",
+                table: "Districts");
+            
+            migrationBuilder.AddColumn<double>(
+                name: "Area",
+                table: "Districts",
+                type: "double precision",
+                nullable: false, defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<Polygon>(
+                name: "Geometry",
+                table: "Districts",
+                type: "geometry",
+                nullable: false, defaultValue: Polygon.Empty);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Geometry",
+                table: "Districts");
+            
+            migrationBuilder.DropColumn(
+                name: "Area",
+                table: "Districts");
+            
+            migrationBuilder.AddColumn<double>(
+                name: "Area",
+                table: "Districts",
+                type: "double precision",
+                nullable: false, defaultValue: 0.0);
+        }
+    }
+}

--- a/GdanskExplorer/Program.cs
+++ b/GdanskExplorer/Program.cs
@@ -103,10 +103,6 @@ builder.Services.AddAuthentication(x =>
 builder.Services.Configure<AreaCalculationOptions>(
     builder.Configuration.GetSection(AreaCalculationOptions.SectionName));
 
-// builder.Services.AddSingleton<DotSpatialReprojector>(isp =>
-//     new DotSpatialReprojector(ProjectionInfo.FromEpsgCode(4326),
-//     ProjectionInfo.FromProj4String(isp.GetRequiredService<IOptions<AreaCalculationOptions>>().Value.AreaSrid)));
-
 builder.Services.AddSingleton<GpxAreaExtractor>(isp => new GpxAreaExtractor(
     isp.GetRequiredService<IOptions<AreaCalculationOptions>>().Value, isp.GetRequiredService<ILogger<GpxAreaExtractor>>()));
 
@@ -131,6 +127,7 @@ app.MapControllers();
 using (var scope = app.Services.CreateScope())
 {
     var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
     var roles = new[] { "Admin", "User" };
  
     foreach (var role in roles)

--- a/GdanskExplorer/Topology/GpxAreaExtractor.cs
+++ b/GdanskExplorer/Topology/GpxAreaExtractor.cs
@@ -3,7 +3,6 @@ using DotSpatial.Projections;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
-using NetTopologySuite.Operation.Buffer;
 
 namespace GdanskExplorer.Topology;
 


### PR DESCRIPTION
Add:
- district controller for (admin-only) district import and returning the district geometries
- caching of per-district area amounts for each user so they do not have to be recalculated every request

Fix:
- authentication did not put role claims on the JWTs returned, so nobody could authenticate as a given role 